### PR TITLE
StreamBoxにストリーム切り替え機能を追加

### DIFF
--- a/src/app/_components/Button/index.tsx
+++ b/src/app/_components/Button/index.tsx
@@ -2,12 +2,13 @@ import Add from "@material-design-icons/svg/filled/add.svg";
 import Close from "@material-design-icons/svg/filled/close.svg";
 import KeyboardArrowDown from "@material-design-icons/svg/filled/keyboard_arrow_down.svg";
 import KeyboardArrowUp from "@material-design-icons/svg/filled/keyboard_arrow_up.svg";
+import SwitchVideo from "@material-design-icons/svg/filled/switch_video.svg";
 import classNames from "classnames";
-import { ComponentPropsWithoutRef, FC } from "react";
+import { ComponentPropsWithoutRef, FC, memo } from "react";
 
 interface Props extends ComponentPropsWithoutRef<"button"> {
   className?: string;
-  iconType: "add" | "close" | "move_up" | "move_down";
+  iconType: "add" | "close" | "move_up" | "move_down" | "switch_video";
   iconColor?: string;
 }
 
@@ -21,15 +22,17 @@ function getIcon(iconType: Props["iconType"]) {
       return KeyboardArrowUp;
     case "move_down":
       return KeyboardArrowDown;
+    case "switch_video":
+      return SwitchVideo;
   }
 }
 
-export const Button: FC<Props> = ({
+export const Button: FC<Props> = memo(function Button({
   className,
   iconType,
   iconColor,
   ...props
-}) => {
+}) {
   const Icon = getIcon(iconType);
 
   return (
@@ -48,4 +51,4 @@ export const Button: FC<Props> = ({
       />
     </button>
   );
-};
+});

--- a/src/app/_components/StreamBox/index.tsx
+++ b/src/app/_components/StreamBox/index.tsx
@@ -13,6 +13,7 @@ interface Props {
   onClickClose?: (id: string) => void;
   onClickMoveUp?: (id: string) => void;
   onClickMoveDown?: (id: string) => void;
+  onClickSwitchVideo?: (id: string) => void;
 }
 
 export const StreamBox: FC<Props> = ({
@@ -22,6 +23,7 @@ export const StreamBox: FC<Props> = ({
   onClickClose,
   onClickMoveUp,
   onClickMoveDown,
+  onClickSwitchVideo,
 }) => {
   const [isHovered, setIsHovered] = useState(false);
 
@@ -44,6 +46,10 @@ export const StreamBox: FC<Props> = ({
     onClickMoveDown?.(id);
   }, [id, onClickMoveDown]);
 
+  const switchVideoHandler = useCallback(() => {
+    onClickSwitchVideo?.(id);
+  }, [id, onClickSwitchVideo]);
+
   return (
     <Rnd>
       <div
@@ -65,6 +71,12 @@ export const StreamBox: FC<Props> = ({
             "opacity-0 group-hover/video-box:opacity-100",
           )}
         >
+          <Button
+            className='pointer-events-auto'
+            iconType='switch_video'
+            iconColor={color}
+            onClick={switchVideoHandler}
+          />
           <Button
             className='pointer-events-auto'
             iconType='move_up'

--- a/src/app/_container.tsx
+++ b/src/app/_container.tsx
@@ -65,6 +65,28 @@ export const Container: FC = () => {
     });
   }, []);
 
+  const clickSwitchVideoHandler = useCallback(async (id: string) => {
+    try {
+      // 新しいストリームを取得
+      const newCaptureStream =
+        await navigator.mediaDevices.getDisplayMedia(displayMediaOptions);
+
+      setMediaItems((prev) =>
+        prev.map((item) => {
+          if (item.id === id) {
+            // 古いストリームを停止
+            item.media.getTracks().forEach((track) => track.stop());
+            // 新しいストリームに置き換え
+            return { ...item, media: newCaptureStream };
+          }
+          return item;
+        }),
+      );
+    } catch (_) {
+      // noop
+    }
+  }, []);
+
   return (
     <MainCanvas onClickAdd={clickAddHandler}>
       {mediaItems.map((item) => (
@@ -74,6 +96,7 @@ export const Container: FC = () => {
           onClickClose={clickCloseHandler}
           onClickMoveUp={clickMoveUpHandler}
           onClickMoveDown={clickMoveDownHandler}
+          onClickSwitchVideo={clickSwitchVideoHandler}
         />
       ))}
     </MainCanvas>


### PR DESCRIPTION
## Summary
- StreamBoxにビデオストリームを切り替えるボタンを追加
- 既存のストリームを停止して新しいストリームに切り替える機能を実装
- ボタンのデザインとカラーテーマの統一性を維持

## Changes
- **新しいアイコンボタン**
  - Button コンポーネントに `switch_video` アイコンタイプを追加
  - Material Design Icons の SwitchVideo アイコンを使用

- **StreamBox UI の更新**
  - ホバー時にストリーム切り替えボタンを表示
  - 既存のボタン（上下移動、クローズ）と統一されたデザイン
  - パステルカラーでアイコン色を統一

- **ストリーム切り替えロジック**
  - `clickSwitchVideoHandler` で新しいストリーム取得
  - 古いストリームのトラックを適切に停止
  - 新しいストリームに置き換え（色やレイアウトは維持）

## Test plan
- [x] StreamBoxホバー時にビデオ切り替えボタンが表示される
- [x] ボタンクリック時に画面選択ダイアログが表示される
- [x] 新しいストリーム選択後、既存のビデオが切り替わる
- [x] 古いストリームが適切に停止される
- [x] StreamBoxの色とレイアウトが維持される

🤖 Generated with [Claude Code](https://claude.ai/code)