### PR TITLE
refactor: Improve crop boundary constraints and code organization

### DIFF
--- a/src/components/StreamBox/StreamBoxInner/index.stories.tsx
+++ b/src/components/StreamBox/StreamBoxInner/index.stories.tsx
@@ -1,4 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ComponentProps } from "react";
+import { useArgs } from "storybook/preview-api";
 
 import { StreamBoxInner } from "./index";
 import { StreamBoxTransform } from "./types";
@@ -31,6 +33,42 @@ const meta: Meta<typeof StreamBoxInner> = {
       description: "ボーダーの色",
     },
   },
+  decorators: [
+    (Story) => {
+      const [args, setArgs] = useArgs<ComponentProps<typeof StreamBoxInner>>();
+      return (
+        <Story
+          args={{
+            ...args,
+            buttons: (
+              <button
+                style={{
+                  backgroundColor: args.mode === "crop" ? "#1ec35d" : "#f56f1c",
+                  color: "white",
+                  padding: "0.5rem",
+                  border: "none",
+                  borderRadius: "0.25rem",
+                  cursor: "pointer",
+                  position: "absolute",
+                  top: "1rem",
+                  right: "1rem",
+                  boxShadow: "0 2px 4px rgba(0,0,0,0.3)",
+                }}
+                onClick={() =>
+                  setArgs({
+                    ...args,
+                    mode: args.mode === "crop" ? "resize" : "crop",
+                  })
+                }
+              >
+                {args.mode === "crop" ? "current: crop" : "current: resize"}
+              </button>
+            ),
+          }}
+        />
+      );
+    },
+  ],
 };
 
 export default meta;
@@ -42,8 +80,6 @@ const baseTransform: StreamBoxTransform = {
   crop: { x: 0, y: 0, width: 400, height: 300 },
   scale: 1,
 };
-
-// クロッピングパターン
 
 // サンプルSVGグリッドコンポーネント（videoタグと同じ挙動）
 const TestGrid = () => (

--- a/src/components/StreamBox/StreamBoxInner/index.tsx
+++ b/src/components/StreamBox/StreamBoxInner/index.tsx
@@ -148,12 +148,19 @@ export const StreamBoxInner: FC<Props> = ({
         handle: dragStartData.handle,
       } as const;
 
+      const contentSize = {
+        width: contentWidth,
+        height: contentHeight,
+      } as const;
+
       if (dragStartData.dragOrResize === "drag") {
         if (mode === "resize") {
           setCurrentTransform(contentDragOnResize(initialTransform, delta));
         }
         if (mode === "crop") {
-          setCurrentTransform(contentDragOnCrop(initialTransform, delta));
+          setCurrentTransform(
+            contentDragOnCrop(initialTransform, delta, contentSize),
+          );
         }
       }
 
@@ -162,11 +169,13 @@ export const StreamBoxInner: FC<Props> = ({
           setCurrentTransform(handleDragOnResize(initialTransform, delta));
         }
         if (mode === "crop") {
-          setCurrentTransform(handleDragOnCrop(initialTransform, delta));
+          setCurrentTransform(
+            handleDragOnCrop(initialTransform, delta, contentSize),
+          );
         }
       }
     },
-    [mode, dragStartData],
+    [mode, dragStartData, contentWidth, contentHeight],
   );
 
   const handleMouseUp = useCallback(() => {

--- a/src/index.css
+++ b/src/index.css
@@ -32,6 +32,8 @@
 }
 
 body {
+  height: 100vh;
+  height: 100dvh;
   color: rgb(var(--foreground-rgb));
   background: linear-gradient(
       to bottom,


### PR DESCRIPTION
## Summary

- Implement robust boundary constraints for crop operations
- Add comprehensive test coverage with 30 test cases
- Refactor code for better readability and maintainability
- Improve Storybook with interactive mode switching

## Key Changes

### 🔧 Boundary Constraints
- **Content drag limits**: Prevent crop area from moving outside content bounds
- **Handle resize limits**: Prevent crop handles from extending beyond content size
- **Minimum size enforcement**: Maintain 50px minimum crop dimensions

### 🧹 Code Quality Improvements
- Add `adjust()` utility function to reduce duplication
- Rename parameters (`initialData` → `current`) for clarity
- Use direction flags (`isWest`, `isNorth`) for cleaner conditionals
- Separate X/Y axis processing in crop operations
- Inline calculations where appropriate

### 🧪 Test Coverage
- 30 comprehensive test cases covering all public functions
- Boundary condition testing for edge cases
- Scale variation tests (0.5, 1.0, 2.0)
- Mathematical accuracy verification

### 📚 Storybook Enhancement
- Interactive mode switching button (resize ↔ crop)
- Better visual feedback for current mode
- Improved testing interface

## Technical Details

### Functions Enhanced
- `contentDragOnCrop`: Content boundary clamping
- `handleDragOnCrop`: Handle resize with content size limits
- `handleDragOnResize`: Cleaner directional logic
- All functions: Better parameter naming and structure

### Boundary Logic
```typescript
// Content drag constraints
x: adjust(current.crop.x - delta.x / current.scale, {
  min: 0,
  max: contentSize.width - current.crop.width,
})

// Handle resize constraints  
width: adjust(current.crop.width + deltaXScaled, {
  min: minCropSize,
  max: contentSize.width - current.crop.x,
})
```

## Test Plan
- [x] All existing tests pass (30/30)
- [x] TypeScript compilation clean
- [x] ESLint checks pass
- [x] Interactive testing in Storybook
- [x] Boundary constraints verified manually

🤖 Generated with [Claude Code](https://claude.ai/code)