### PR TITLE
feat: リサイズ可能なMemoBoxコンポーネントを追加

### DIFF
--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -2,6 +2,7 @@ import { FC, useCallback, useState } from "react";
 
 import { ClockBox } from "./components/ClockBox";
 import { MainCanvas } from "./components/MainCanvas";
+import { MemoBox } from "./components/MemoBox";
 import { StreamBox } from "./components/StreamBox";
 import { TimerBox } from "./components/TimerBox";
 import { swap } from "./utils/array";
@@ -25,15 +26,11 @@ type StreamItem = BaseItem & {
   media: MediaStream;
 };
 
-type TimerItem = BaseItem & {
-  type: "timer";
+type OtherItem = BaseItem & {
+  type: "timer" | "clock" | "memo";
 };
 
-type ClockItem = BaseItem & {
-  type: "clock";
-};
-
-type MediaItem = StreamItem | TimerItem | ClockItem;
+type MediaItem = StreamItem | OtherItem;
 
 async function captureNewStream() {
   try {
@@ -107,6 +104,15 @@ const ItemBox: FC<{
           onClickMoveDown={moveDownHandler}
         />
       );
+    case "memo":
+      return (
+        <MemoBox
+          {...item}
+          onClickClose={closeHandler}
+          onClickMoveUp={moveUpHandler}
+          onClickMoveDown={moveDownHandler}
+        />
+      );
   }
 };
 
@@ -130,22 +136,11 @@ export const Container: FC = () => {
     ]);
   }, []);
 
-  const clickAddTimerHandler = useCallback(() => {
+  const clickAddOtherItemHandler = useCallback((type: OtherItem["type"]) => {
     setMediaItems((prev) => [
       ...prev,
       {
-        type: "timer",
-        id: crypto.randomUUID(),
-        color: getPastelColor(prev.length),
-      },
-    ]);
-  }, []);
-
-  const clickAddClockHandler = useCallback(() => {
-    setMediaItems((prev) => [
-      ...prev,
-      {
-        type: "clock",
+        type,
         id: crypto.randomUUID(),
         color: getPastelColor(prev.length),
       },
@@ -200,8 +195,9 @@ export const Container: FC = () => {
   return (
     <MainCanvas
       onClickAdd={clickAddHandler}
-      onClickAddTimer={clickAddTimerHandler}
-      onClickAddClock={clickAddClockHandler}
+      onClickAddTimer={() => clickAddOtherItemHandler("timer")}
+      onClickAddClock={() => clickAddOtherItemHandler("clock")}
+      onClickAddMemo={() => clickAddOtherItemHandler("memo")}
       isEmpty={mediaItems.length === 0}
     >
       {mediaItems.map((item) => (

--- a/src/components/BoxControlButtons/index.tsx
+++ b/src/components/BoxControlButtons/index.tsx
@@ -1,0 +1,47 @@
+import { FC } from "react";
+
+import { Button } from "../Button";
+
+type Props = {
+  color: string;
+  onClickMoveUp?: () => void;
+  onClickMoveDown?: () => void;
+  onClickClose?: () => void;
+};
+
+export const BoxControlButtons: FC<Props> = ({
+  color,
+  onClickMoveUp,
+  onClickMoveDown,
+  onClickClose,
+}) => {
+  return (
+    <div
+      className={`
+        pointer-events-none absolute top-0 right-0 flex flex-row gap-2 p-4
+      `}
+    >
+      <Button
+        className='pointer-events-auto'
+        iconType='move_up'
+        iconColor={color}
+        onClick={onClickMoveUp}
+        title='前面に移動'
+      />
+      <Button
+        className='pointer-events-auto'
+        iconType='move_down'
+        iconColor={color}
+        onClick={onClickMoveDown}
+        title='背面に移動'
+      />
+      <Button
+        className='pointer-events-auto'
+        iconType='close'
+        iconColor={color}
+        onClick={onClickClose}
+        title='閉じる'
+      />
+    </div>
+  );
+};

--- a/src/components/BoxControlButtons/index.tsx
+++ b/src/components/BoxControlButtons/index.tsx
@@ -2,6 +2,8 @@ import { FC } from "react";
 
 import { Button } from "../Button";
 
+import { t } from "@/i18n";
+
 type Props = {
   color: string;
   onClickMoveUp?: () => void;
@@ -26,21 +28,21 @@ export const BoxControlButtons: FC<Props> = ({
         iconType='move_up'
         iconColor={color}
         onClick={onClickMoveUp}
-        title='前面に移動'
+        title={t("streamBox.bringToFront")}
       />
       <Button
         className='pointer-events-auto'
         iconType='move_down'
         iconColor={color}
         onClick={onClickMoveDown}
-        title='背面に移動'
+        title={t("streamBox.sendToBack")}
       />
       <Button
         className='pointer-events-auto'
         iconType='close'
         iconColor={color}
         onClick={onClickClose}
-        title='閉じる'
+        title={t("streamBox.closeStream")}
       />
     </div>
   );

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -5,6 +5,7 @@ import FullscreenExit from "@material-design-icons/svg/filled/fullscreen_exit.sv
 import Help from "@material-design-icons/svg/filled/help.svg?react";
 import KeyboardArrowDown from "@material-design-icons/svg/filled/keyboard_arrow_down.svg?react";
 import KeyboardArrowUp from "@material-design-icons/svg/filled/keyboard_arrow_up.svg?react";
+import Note from "@material-design-icons/svg/filled/note.svg?react";
 import Schedule from "@material-design-icons/svg/filled/schedule.svg?react";
 import SwitchVideo from "@material-design-icons/svg/filled/switch_video.svg?react";
 import Timer from "@material-design-icons/svg/filled/timer.svg?react";
@@ -21,6 +22,7 @@ interface Props extends ComponentPropsWithoutRef<"button"> {
     | "help"
     | "move_up"
     | "move_down"
+    | "note"
     | "switch_video"
     | "timer"
     | "schedule";
@@ -43,6 +45,8 @@ function getIcon(iconType: Props["iconType"]) {
       return KeyboardArrowUp;
     case "move_down":
       return KeyboardArrowDown;
+    case "note":
+      return Note;
     case "switch_video":
       return SwitchVideo;
     case "timer":

--- a/src/components/ClockBox/index.tsx
+++ b/src/components/ClockBox/index.tsx
@@ -1,6 +1,6 @@
 import { FC, useState, useEffect } from "react";
 
-import { Button } from "../Button";
+import { BoxControlButtons } from "../BoxControlButtons";
 import { FlexibleBox } from "../FlexibleBox";
 
 const BOX_WIDTH = 280,
@@ -103,33 +103,12 @@ export const ClockBox: FC<Props> = ({
       borderColor={color}
       transparent
       buttons={
-        <div
-          className={`
-            pointer-events-none absolute top-0 right-0 flex flex-row gap-2 p-4
-          `}
-        >
-          <Button
-            className='pointer-events-auto'
-            iconType='move_up'
-            iconColor={color}
-            onClick={onClickMoveUp}
-            title='前面に移動'
-          />
-          <Button
-            className='pointer-events-auto'
-            iconType='move_down'
-            iconColor={color}
-            onClick={onClickMoveDown}
-            title='背面に移動'
-          />
-          <Button
-            className='pointer-events-auto'
-            iconType='close'
-            iconColor={color}
-            onClick={onClickClose}
-            title='閉じる'
-          />
-        </div>
+        <BoxControlButtons
+          color={color}
+          onClickMoveUp={onClickMoveUp}
+          onClickMoveDown={onClickMoveDown}
+          onClickClose={onClickClose}
+        />
       }
     >
       <ClockBoxView currentTime={currentTime} color={color} />

--- a/src/components/MainCanvas/index.tsx
+++ b/src/components/MainCanvas/index.tsx
@@ -10,6 +10,7 @@ type Props = PropsWithChildren<{
   onClickAdd?: () => void;
   onClickAddTimer?: () => void;
   onClickAddClock?: () => void;
+  onClickAddMemo?: () => void;
   isEmpty?: boolean;
 }>;
 
@@ -19,6 +20,7 @@ export const MainCanvas: FC<Props> = ({
   onClickAdd,
   onClickAddTimer,
   onClickAddClock,
+  onClickAddMemo,
   isEmpty = false,
 }) => {
   return (
@@ -37,6 +39,12 @@ export const MainCanvas: FC<Props> = ({
           isEmpty ? "opacity-100" : "opacity-0 group-hover/main:opacity-100",
         )}
       >
+        <Button
+          className='pointer-events-auto'
+          iconType='note'
+          onClick={onClickAddMemo}
+          title={t("mainCanvas.addMemo")}
+        />
         <Button
           className='pointer-events-auto'
           iconType='schedule'

--- a/src/components/MemoBox/MemoBoxView.stories.tsx
+++ b/src/components/MemoBox/MemoBoxView.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { MemoBoxView } from "./index";
+
+const meta = {
+  component: MemoBoxView,
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className='bg-gray-800 p-8'>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof MemoBoxView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  args: {
+    memo: "",
+    color: "#60a5fa",
+    onMemoChange: () => {},
+    width: 400,
+    height: 300,
+  },
+};
+
+export const WithText: Story = {
+  args: {
+    memo: "これはサンプルのメモです。\n複数行のテキストも入力できます。",
+    color: "#34d399",
+    onMemoChange: () => {},
+    width: 400,
+    height: 300,
+  },
+};
+
+export const LongText: Story = {
+  args: {
+    memo: `長いテキストのサンプルです。
+これはプレゼンテーション用のメモボックスです。
+複数行にわたる長いテキストを入力することができます。
+
+- 箇条書き
+- リスト形式
+- なども使えます
+
+スクロールして全文を確認できます。
+サイズを変更することで、より多くのテキストを表示できます。`,
+    color: "#f87171",
+    onMemoChange: () => {},
+    width: 400,
+    height: 300,
+  },
+};
+
+export const LargeSize: Story = {
+  args: {
+    memo: "大きいサイズのメモボックスです。",
+    color: "#fbbf24",
+    onMemoChange: () => {},
+    width: 600,
+    height: 400,
+  },
+};
+
+export const SmallSize: Story = {
+  args: {
+    memo: "小さいメモ",
+    color: "#ec4899",
+    onMemoChange: () => {},
+    width: 250,
+    height: 150,
+  },
+};

--- a/src/components/MemoBox/MemoBoxView.stories.tsx
+++ b/src/components/MemoBox/MemoBoxView.stories.tsx
@@ -24,8 +24,6 @@ export const Empty: Story = {
     memo: "",
     color: "#60a5fa",
     onMemoChange: () => {},
-    width: 400,
-    height: 300,
   },
 };
 
@@ -34,8 +32,6 @@ export const WithText: Story = {
     memo: "これはサンプルのメモです。\n複数行のテキストも入力できます。",
     color: "#34d399",
     onMemoChange: () => {},
-    width: 400,
-    height: 300,
   },
 };
 
@@ -53,27 +49,5 @@ export const LongText: Story = {
 サイズを変更することで、より多くのテキストを表示できます。`,
     color: "#f87171",
     onMemoChange: () => {},
-    width: 400,
-    height: 300,
-  },
-};
-
-export const LargeSize: Story = {
-  args: {
-    memo: "大きいサイズのメモボックスです。",
-    color: "#fbbf24",
-    onMemoChange: () => {},
-    width: 600,
-    height: 400,
-  },
-};
-
-export const SmallSize: Story = {
-  args: {
-    memo: "小さいメモ",
-    color: "#ec4899",
-    onMemoChange: () => {},
-    width: 250,
-    height: 150,
   },
 };

--- a/src/components/MemoBox/MemoBoxView.stories.tsx
+++ b/src/components/MemoBox/MemoBoxView.stories.tsx
@@ -7,13 +7,6 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  decorators: [
-    (Story) => (
-      <div className='bg-gray-800 p-8'>
-        <Story />
-      </div>
-    ),
-  ],
 } satisfies Meta<typeof MemoBoxView>;
 
 export default meta;

--- a/src/components/MemoBox/index.stories.tsx
+++ b/src/components/MemoBox/index.stories.tsx
@@ -7,13 +7,6 @@ const meta = {
   parameters: {
     layout: "fullscreen",
   },
-  decorators: [
-    (Story) => (
-      <div className='h-screen w-screen bg-gray-800'>
-        <Story />
-      </div>
-    ),
-  ],
 } satisfies Meta<typeof MemoBox>;
 
 export default meta;

--- a/src/components/MemoBox/index.stories.tsx
+++ b/src/components/MemoBox/index.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { MemoBox } from "./index";
+
+const meta = {
+  component: MemoBox,
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [
+    (Story) => (
+      <div className='h-screen w-screen bg-gray-800'>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof MemoBox>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    color: "#60a5fa",
+  },
+};

--- a/src/components/MemoBox/index.tsx
+++ b/src/components/MemoBox/index.tsx
@@ -1,6 +1,6 @@
 import { FC, useState } from "react";
 
-import { Button } from "../Button";
+import { BoxControlButtons } from "../BoxControlButtons";
 import { FlexibleBox } from "../FlexibleBox";
 
 const DEFAULT_BOX_WIDTH = 400;
@@ -25,9 +25,9 @@ export const MemoBoxView: FC<MemoBoxViewProps> = ({
   onMemoChange,
 }) => {
   return (
-    <div className={`
-      pointer-events-auto h-full w-full rounded-2xl bg-black/60 p-3
-    `}>
+    <div
+      className={`pointer-events-auto h-full w-full rounded-2xl bg-black/60 p-3`}
+    >
       <textarea
         value={memo}
         onChange={(e) => onMemoChange(e.target.value)}
@@ -59,33 +59,12 @@ export const MemoBox: FC<Props> = ({
       transparent
       borderColor={color}
       buttons={
-        <div
-          className={`
-            pointer-events-none absolute top-0 right-0 flex flex-row gap-2 p-4
-          `}
-        >
-          <Button
-            className='pointer-events-auto'
-            iconType='move_up'
-            iconColor={color}
-            onClick={onClickMoveUp}
-            title='前面に移動'
-          />
-          <Button
-            className='pointer-events-auto'
-            iconType='move_down'
-            iconColor={color}
-            onClick={onClickMoveDown}
-            title='背面に移動'
-          />
-          <Button
-            className='pointer-events-auto'
-            iconType='close'
-            iconColor={color}
-            onClick={onClickClose}
-            title='閉じる'
-          />
-        </div>
+        <BoxControlButtons
+          color={color}
+          onClickMoveUp={onClickMoveUp}
+          onClickMoveDown={onClickMoveDown}
+          onClickClose={onClickClose}
+        />
       }
     >
       <MemoBoxView memo={memo} color={color} onMemoChange={setMemo} />

--- a/src/components/MemoBox/index.tsx
+++ b/src/components/MemoBox/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useState, useRef, useEffect } from "react";
+import { FC, useState } from "react";
 
 import { Button } from "../Button";
 import { FlexibleBox } from "../FlexibleBox";
@@ -17,40 +17,29 @@ type MemoBoxViewProps = {
   memo: string;
   color: string;
   onMemoChange: (value: string) => void;
-  width: number;
-  height: number;
 };
 
 export const MemoBoxView: FC<MemoBoxViewProps> = ({
   memo,
   color,
   onMemoChange,
-  width,
-  height,
 }) => {
   return (
-    <svg
-      viewBox={`0 0 ${width} ${height}`}
-      className={`pointer-events-auto h-full w-full`}
-    >
-      {/* Background */}
-      <rect width={width} height={height} rx={16} fill='#00000099' />
-
-      {/* Textarea */}
-      <foreignObject x='10' y='10' width={width - 20} height={height - 20}>
-        <textarea
-          value={memo}
-          onChange={(e) => onMemoChange(e.target.value)}
-          onMouseDown={(e) => e.stopPropagation()}
-          placeholder='メモを入力...'
-          className={`
-            h-full w-full resize-none rounded-lg border-2 bg-transparent p-3
-            font-sans text-lg text-white placeholder-gray-400 outline-none
-          `}
-          style={{ borderColor: color }}
-        />
-      </foreignObject>
-    </svg>
+    <div className={`
+      pointer-events-auto h-full w-full rounded-2xl bg-black/60 p-3
+    `}>
+      <textarea
+        value={memo}
+        onChange={(e) => onMemoChange(e.target.value)}
+        onMouseDown={(e) => e.stopPropagation()}
+        placeholder='メモを入力...'
+        className={`
+          h-full w-full resize-none rounded-lg border-2 bg-transparent p-3
+          font-sans text-lg text-white placeholder-gray-400 outline-none
+        `}
+        style={{ borderColor: color }}
+      />
+    </div>
   );
 };
 
@@ -61,29 +50,6 @@ export const MemoBox: FC<Props> = ({
   color,
 }) => {
   const [memo, setMemo] = useState("");
-  const [boxSize, setBoxSize] = useState({
-    width: DEFAULT_BOX_WIDTH,
-    height: DEFAULT_BOX_HEIGHT,
-  });
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  // FlexibleBoxのサイズ変更を検知
-  useEffect(() => {
-    if (!containerRef.current) return;
-
-    const resizeObserver = new ResizeObserver((entries) => {
-      for (const entry of entries) {
-        const { width, height } = entry.contentRect;
-        setBoxSize({ width, height });
-      }
-    });
-
-    resizeObserver.observe(containerRef.current);
-
-    return () => {
-      resizeObserver.disconnect();
-    };
-  }, []);
 
   return (
     <FlexibleBox
@@ -122,15 +88,7 @@ export const MemoBox: FC<Props> = ({
         </div>
       }
     >
-      <div ref={containerRef} className='h-full w-full'>
-        <MemoBoxView
-          memo={memo}
-          color={color}
-          onMemoChange={setMemo}
-          width={boxSize.width}
-          height={boxSize.height}
-        />
-      </div>
+      <MemoBoxView memo={memo} color={color} onMemoChange={setMemo} />
     </FlexibleBox>
   );
 };

--- a/src/components/MemoBox/index.tsx
+++ b/src/components/MemoBox/index.tsx
@@ -1,0 +1,136 @@
+import { FC, useState, useRef, useEffect } from "react";
+
+import { Button } from "../Button";
+import { FlexibleBox } from "../FlexibleBox";
+
+const DEFAULT_BOX_WIDTH = 400;
+const DEFAULT_BOX_HEIGHT = 300;
+
+type Props = {
+  onClickClose?: () => void;
+  onClickMoveUp?: () => void;
+  onClickMoveDown?: () => void;
+  color: string;
+};
+
+type MemoBoxViewProps = {
+  memo: string;
+  color: string;
+  onMemoChange: (value: string) => void;
+  width: number;
+  height: number;
+};
+
+export const MemoBoxView: FC<MemoBoxViewProps> = ({
+  memo,
+  color,
+  onMemoChange,
+  width,
+  height,
+}) => {
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      className={`pointer-events-auto h-full w-full`}
+    >
+      {/* Background */}
+      <rect width={width} height={height} rx={16} fill='#00000099' />
+
+      {/* Textarea */}
+      <foreignObject x='10' y='10' width={width - 20} height={height - 20}>
+        <textarea
+          value={memo}
+          onChange={(e) => onMemoChange(e.target.value)}
+          onMouseDown={(e) => e.stopPropagation()}
+          placeholder='メモを入力...'
+          className={`
+            h-full w-full resize-none rounded-lg border-2 bg-transparent p-3
+            font-sans text-lg text-white placeholder-gray-400 outline-none
+          `}
+          style={{ borderColor: color }}
+        />
+      </foreignObject>
+    </svg>
+  );
+};
+
+export const MemoBox: FC<Props> = ({
+  onClickClose,
+  onClickMoveUp,
+  onClickMoveDown,
+  color,
+}) => {
+  const [memo, setMemo] = useState("");
+  const [boxSize, setBoxSize] = useState({
+    width: DEFAULT_BOX_WIDTH,
+    height: DEFAULT_BOX_HEIGHT,
+  });
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // FlexibleBoxのサイズ変更を検知
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        setBoxSize({ width, height });
+      }
+    });
+
+    resizeObserver.observe(containerRef.current);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
+
+  return (
+    <FlexibleBox
+      contentWidth={DEFAULT_BOX_WIDTH}
+      contentHeight={DEFAULT_BOX_HEIGHT}
+      mode='resize'
+      transparent
+      borderColor={color}
+      buttons={
+        <div
+          className={`
+            pointer-events-none absolute top-0 right-0 flex flex-row gap-2 p-4
+          `}
+        >
+          <Button
+            className='pointer-events-auto'
+            iconType='move_up'
+            iconColor={color}
+            onClick={onClickMoveUp}
+            title='前面に移動'
+          />
+          <Button
+            className='pointer-events-auto'
+            iconType='move_down'
+            iconColor={color}
+            onClick={onClickMoveDown}
+            title='背面に移動'
+          />
+          <Button
+            className='pointer-events-auto'
+            iconType='close'
+            iconColor={color}
+            onClick={onClickClose}
+            title='閉じる'
+          />
+        </div>
+      }
+    >
+      <div ref={containerRef} className='h-full w-full'>
+        <MemoBoxView
+          memo={memo}
+          color={color}
+          onMemoChange={setMemo}
+          width={boxSize.width}
+          height={boxSize.height}
+        />
+      </div>
+    </FlexibleBox>
+  );
+};

--- a/src/components/TimerBox/index.tsx
+++ b/src/components/TimerBox/index.tsx
@@ -1,6 +1,6 @@
 import { FC, useState, useEffect, ReactNode } from "react";
 
-import { Button } from "../Button";
+import { BoxControlButtons } from "../BoxControlButtons";
 import { FlexibleBox } from "../FlexibleBox";
 
 const BOX_WIDTH = 280,
@@ -217,33 +217,12 @@ export const TimerBox: FC<Props> = ({
       transparent
       borderColor={color}
       buttons={
-        <div
-          className={`
-            pointer-events-none absolute top-0 right-0 flex flex-row gap-2 p-4
-          `}
-        >
-          <Button
-            className='pointer-events-auto'
-            iconType='move_up'
-            iconColor={color}
-            onClick={onClickMoveUp}
-            title='前面に移動'
-          />
-          <Button
-            className='pointer-events-auto'
-            iconType='move_down'
-            iconColor={color}
-            onClick={onClickMoveDown}
-            title='背面に移動'
-          />
-          <Button
-            className='pointer-events-auto'
-            iconType='close'
-            iconColor={color}
-            onClick={onClickClose}
-            title='閉じる'
-          />
-        </div>
+        <BoxControlButtons
+          color={color}
+          onClickMoveUp={onClickMoveUp}
+          onClickMoveDown={onClickMoveDown}
+          onClickClose={onClickClose}
+        />
       }
     >
       <TimerBoxView

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -14,6 +14,7 @@ export const en = {
   "mainCanvas.startCapture": "Start screen capture",
   "mainCanvas.addClock": "Add Clock",
   "mainCanvas.addTimer": "Add Timer",
+  "mainCanvas.addMemo": "Add Memo",
 
   // Stream Box
   "streamBox.resize": "Resize",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -17,6 +17,7 @@ export const ja = {
   "mainCanvas.startCapture": "画面キャプチャを開始",
   "mainCanvas.addClock": "時計を追加",
   "mainCanvas.addTimer": "タイマーを追加",
+  "mainCanvas.addMemo": "メモを追加",
 
   // Stream Box
   "streamBox.resize": "リサイズ",


### PR DESCRIPTION
## Summary

プレゼンテーション用のリサイズ可能なメモボックスコンポーネントを実装しました。

- リサイズ可能な長文メモ入力ボックス（MemoBox）を追加
- 右上ボタン群の左端にメモ追加ボタンを配置
- コード重複を削減するためBoxControlButtonsコンポーネントを共通化

## Changes

### 機能追加
- **MemoBox**: テキスト入力可能なリサイズ対応ボックス
  - シンプルなHTML実装（SVG不要）
  - 長文対応（スクロール表示）
  - View分離パターンで実装
  - Storybook対応

- **UI改善**: 右上ボタン群の左端にメモ追加ボタンを配置
  - Buttonコンポーネントに`note`アイコンを追加
  - 国際化対応（日本語/英語）

### リファクタリング
- **型定義の整理**: `TimerItem`/`ClockItem`/`MemoItem`を`OtherItem`に統合
- **コード共通化**: `BoxControlButtons`コンポーネントを新規作成
  - TimerBox/ClockBox/MemoBoxで重複していたボタン群を共通化
  - 87行のコード削減

## Test plan

- [ ] メモボックスの追加・削除が正常に動作する
- [ ] メモボックスのリサイズが正常に動作する
- [ ] テキスト入力・編集が正常に動作する
- [ ] 長文入力時にスクロールが表示される
- [ ] 既存のTimerBox/ClockBoxが正常に動作する
- [ ] Storybookで各ストーリーが正常に表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)