### PR TITLE
feat: FlexibleBoxにresize-contentモードを追加

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,7 +15,8 @@
       "Bash(grep:*)",
       "Bash(npm run fix:*)",
       "Bash(mkdir:*)",
-      "Bash(touch:*)"
+      "Bash(touch:*)",
+      "Bash(npm test:*)"
     ],
     "deny": []
   }

--- a/src/components/FlexibleBox/functions.ts
+++ b/src/components/FlexibleBox/functions.ts
@@ -304,3 +304,158 @@ export function handleDragOnCrop(
     },
   };
 }
+
+if (import.meta.vitest) {
+  const { describe, it, expect } = import.meta.vitest;
+
+  describe("handleDragOnResizeContent", () => {
+    const baseTransform: FlexibleBoxTransform = {
+      crop: {
+        x: 0,
+        y: 0,
+        width: 400,
+        height: 300,
+      },
+      scale: 1,
+      screenPosition: { x: 100, y: 100 },
+      contentSize: { width: 400, height: 300 },
+    };
+
+    it("should resize content width when dragging east handle", () => {
+      const result = handleDragOnResizeContent(baseTransform, {
+        x: 50,
+        y: 0,
+        handle: "e",
+      });
+
+      expect(result.contentSize.width).toBe(450);
+      expect(result.contentSize.height).toBe(300);
+      expect(result.crop.width).toBe(450);
+      expect(result.crop.height).toBe(300);
+      expect(result.screenPosition).toEqual({ x: 100, y: 100 });
+    });
+
+    it("should resize content height when dragging south handle", () => {
+      const result = handleDragOnResizeContent(baseTransform, {
+        x: 0,
+        y: 80,
+        handle: "s",
+      });
+
+      expect(result.contentSize.width).toBe(400);
+      expect(result.contentSize.height).toBe(380);
+      expect(result.crop.width).toBe(400);
+      expect(result.crop.height).toBe(380);
+      expect(result.screenPosition).toEqual({ x: 100, y: 100 });
+    });
+
+    it("should resize both width and height when dragging southeast corner", () => {
+      const result = handleDragOnResizeContent(baseTransform, {
+        x: 50,
+        y: 80,
+        handle: "se",
+      });
+
+      expect(result.contentSize.width).toBe(450);
+      expect(result.contentSize.height).toBe(380);
+      expect(result.crop.width).toBe(450);
+      expect(result.crop.height).toBe(380);
+      expect(result.screenPosition).toEqual({ x: 100, y: 100 });
+    });
+
+    it("should resize and adjust position when dragging west handle", () => {
+      const result = handleDragOnResizeContent(baseTransform, {
+        x: 50,
+        y: 0,
+        handle: "w",
+      });
+
+      expect(result.contentSize.width).toBe(350);
+      expect(result.contentSize.height).toBe(300);
+      expect(result.crop.width).toBe(350);
+      expect(result.crop.height).toBe(300);
+      // x position should move left by 50 (widthDelta = 350 - 400 = -50)
+      expect(result.screenPosition.x).toBe(150);
+      expect(result.screenPosition.y).toBe(100);
+    });
+
+    it("should resize and adjust position when dragging north handle", () => {
+      const result = handleDragOnResizeContent(baseTransform, {
+        x: 0,
+        y: 40,
+        handle: "n",
+      });
+
+      expect(result.contentSize.width).toBe(400);
+      expect(result.contentSize.height).toBe(260);
+      expect(result.crop.width).toBe(400);
+      expect(result.crop.height).toBe(260);
+      expect(result.screenPosition.x).toBe(100);
+      // y position should move up by 40 (heightDelta = 260 - 300 = -40)
+      expect(result.screenPosition.y).toBe(140);
+    });
+
+    it("should resize and adjust position when dragging northwest corner", () => {
+      const result = handleDragOnResizeContent(baseTransform, {
+        x: 30,
+        y: 20,
+        handle: "nw",
+      });
+
+      expect(result.contentSize.width).toBe(370);
+      expect(result.contentSize.height).toBe(280);
+      expect(result.crop.width).toBe(370);
+      expect(result.crop.height).toBe(280);
+      // x: 100 + (370 - 400) = 70
+      expect(result.screenPosition.x).toBe(130);
+      // y: 100 + (280 - 300) = 80
+      expect(result.screenPosition.y).toBe(120);
+    });
+
+    it("should enforce minimum size", () => {
+      const result = handleDragOnResizeContent(baseTransform, {
+        x: -500,
+        y: -500,
+        handle: "e",
+      });
+
+      // MIN_SIZE is 100
+      expect(result.contentSize.width).toBe(100);
+      expect(result.crop.width).toBe(100);
+    });
+
+    it("should return unchanged transform when handle is undefined", () => {
+      const result = handleDragOnResizeContent(baseTransform, {
+        x: 50,
+        y: 50,
+      });
+
+      expect(result).toEqual(baseTransform);
+    });
+
+    it("should handle negative delta correctly on east handle", () => {
+      const result = handleDragOnResizeContent(baseTransform, {
+        x: -50,
+        y: 0,
+        handle: "e",
+      });
+
+      expect(result.contentSize.width).toBe(350);
+      expect(result.crop.width).toBe(350);
+      expect(result.screenPosition.x).toBe(100);
+    });
+
+    it("should handle negative delta correctly on west handle", () => {
+      const result = handleDragOnResizeContent(baseTransform, {
+        x: -50,
+        y: 0,
+        handle: "w",
+      });
+
+      expect(result.contentSize.width).toBe(450);
+      expect(result.crop.width).toBe(450);
+      // widthDelta = 450 - 400 = 50, so x = 100 - 50 = 50
+      expect(result.screenPosition.x).toBe(50);
+    });
+  });
+}

--- a/src/components/FlexibleBox/functions.ts
+++ b/src/components/FlexibleBox/functions.ts
@@ -115,6 +115,69 @@ export function handleDragOnResize(
   };
 }
 
+export function handleDragOnResizeContent(
+  current: FlexibleBoxTransform,
+  delta: MouseDelta,
+): FlexibleBoxTransform {
+  if (!delta.handle) {
+    return current;
+  }
+
+  const isWest =
+    delta.handle === "nw" || delta.handle === "sw" || delta.handle === "w";
+  const isNorth =
+    delta.handle === "nw" || delta.handle === "ne" || delta.handle === "n";
+  const isEast =
+    delta.handle === "ne" || delta.handle === "se" || delta.handle === "e";
+  const isSouth =
+    delta.handle === "sw" || delta.handle === "se" || delta.handle === "s";
+
+  // 新しいcontentSize widthとheightを計算
+  const newWidth = (() => {
+    if (isEast) {
+      return Math.max(MIN_SIZE, current.contentSize.width + delta.x);
+    } else if (isWest) {
+      return Math.max(MIN_SIZE, current.contentSize.width - delta.x);
+    }
+    return current.contentSize.width;
+  })();
+
+  const newHeight = (() => {
+    if (isSouth) {
+      return Math.max(MIN_SIZE, current.contentSize.height + delta.y);
+    } else if (isNorth) {
+      return Math.max(MIN_SIZE, current.contentSize.height - delta.y);
+    }
+    return current.contentSize.height;
+  })();
+
+  // screen positionの調整（西・北側のハンドルの場合）
+  const widthDelta = newWidth - current.contentSize.width;
+  const heightDelta = newHeight - current.contentSize.height;
+
+  const x = isWest
+    ? current.screenPosition.x - widthDelta
+    : current.screenPosition.x;
+
+  const y = isNorth
+    ? current.screenPosition.y - heightDelta
+    : current.screenPosition.y;
+
+  return {
+    ...current,
+    contentSize: {
+      width: newWidth,
+      height: newHeight,
+    },
+    crop: {
+      ...current.crop,
+      width: newWidth,
+      height: newHeight,
+    },
+    screenPosition: { x, y },
+  };
+}
+
 export function contentDragOnCrop(
   current: FlexibleBoxTransform,
   delta: MouseDelta,

--- a/src/components/FlexibleBox/index.tsx
+++ b/src/components/FlexibleBox/index.tsx
@@ -15,6 +15,7 @@ import {
   createDefaultTransform,
   handleDragOnCrop,
   handleDragOnResize,
+  handleDragOnResizeContent,
 } from "./functions";
 import { Mode, FlexibleBoxTransform } from "./types";
 import { t } from "../../i18n";
@@ -205,7 +206,7 @@ export const FlexibleBox: FC<Props> = ({
       } as const;
 
       if (dragStartData.dragOrResize === "drag") {
-        if (mode === "resize") {
+        if (mode === "resize" || mode === "resize-content") {
           setCurrentTransform(contentDragOnResize(initialTransform, delta));
         }
         if (mode === "crop") {
@@ -219,6 +220,11 @@ export const FlexibleBox: FC<Props> = ({
         }
         if (mode === "crop") {
           setCurrentTransform(handleDragOnCrop(initialTransform, delta));
+        }
+        if (mode === "resize-content") {
+          setCurrentTransform(
+            handleDragOnResizeContent(initialTransform, delta),
+          );
         }
       }
     },
@@ -322,8 +328,8 @@ export const FlexibleBox: FC<Props> = ({
           <ResizeHandle handle='sw' {...handleProps} />
           <ResizeHandle handle='se' {...handleProps} />
 
-          {/* エッジハンドル（クロップモード時のみ表示） */}
-          {mode === "crop" && (
+          {/* エッジハンドル（クロップモードまたはコンテンツリサイズモード時のみ表示） */}
+          {(mode === "crop" || mode === "resize-content") && (
             <>
               <ResizeHandle handle='n' {...handleProps} />
               <ResizeHandle handle='s' {...handleProps} />

--- a/src/components/FlexibleBox/types.ts
+++ b/src/components/FlexibleBox/types.ts
@@ -23,4 +23,4 @@ export interface FlexibleBoxTransform {
   };
 }
 
-export type Mode = "resize" | "crop";
+export type Mode = "resize" | "crop" | "resize-content";

--- a/src/components/MemoBox/index.tsx
+++ b/src/components/MemoBox/index.tsx
@@ -55,7 +55,7 @@ export const MemoBox: FC<Props> = ({
     <FlexibleBox
       contentWidth={DEFAULT_BOX_WIDTH}
       contentHeight={DEFAULT_BOX_HEIGHT}
-      mode='resize'
+      mode='resize-content'
       transparent
       borderColor={color}
       buttons={


### PR DESCRIPTION
## Summary

MemoBoxで上下左右方向に自由にリサイズできるよう、FlexibleBoxに新しい`resize-content`モードを追加しました。

## Changes

### 新機能
- **resize-contentモード**: contentSizeを直接変更する新しいリサイズモード
  - アスペクト比を維持しない自由なリサイズ
  - 上下左右のエッジハンドルで各方向に独立してリサイズ可能
  - コーナーハンドルで両方向同時にリサイズ可能

### 実装内容
1. **型定義の拡張** ([types.ts](src/components/FlexibleBox/types.ts))
   - `Mode`型に`"resize-content"`を追加

2. **新しいリサイズ関数** ([functions.ts](src/components/FlexibleBox/functions.ts))
   - `handleDragOnResizeContent`関数を新規実装
   - `contentSize`と`crop`を直接変更
   - 西・北側のハンドルでは位置も調整

3. **FlexibleBoxの対応** ([index.tsx](src/components/FlexibleBox/index.tsx))
   - `resize-content`モード時の処理を追加
   - エッジハンドルを`resize-content`モードでも表示

4. **MemoBoxの更新** ([MemoBox/index.tsx](src/components/MemoBox/index.tsx))
   - `mode='resize-content'`に変更

### テスト
- **handleDragOnResizeContentのテスト**: 10個のテストケースで全動作を網羅
  - エッジハンドル/コーナーハンドルの動作確認
  - 位置調整の確認
  - 最小サイズ制約の確認
  - エッジケースの確認

## Test plan

- [ ] MemoBoxのリサイズが上下左右独立して動作する
- [ ] エッジハンドルで片方向のみリサイズできる
- [ ] コーナーハンドルで両方向同時にリサイズできる
- [ ] 西・北側のハンドルで位置が正しく調整される
- [ ] 最小サイズ制約が機能する
- [ ] 既存のTimerBox/ClockBoxが影響を受けない
- [ ] StreamBoxの`resize`モードが正常に動作する
- [ ] テストが全て通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)