### PR TITLE
Add image upload and display functionality

### DIFF
--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -54,54 +54,6 @@ async function captureNewStream() {
   }
 }
 
-async function selectImageFile(): Promise<{
-  src: string;
-  naturalWidth: number;
-  naturalHeight: number;
-} | null> {
-  return new Promise((resolve) => {
-    const input = document.createElement("input");
-    // eslint-disable-next-line functional/immutable-data
-    input.type = "file";
-    // eslint-disable-next-line functional/immutable-data
-    input.accept = "image/*";
-
-    // eslint-disable-next-line functional/immutable-data
-    input.onchange = () => {
-      const file = input.files?.[0];
-      if (!file) {
-        resolve(null);
-        return;
-      }
-
-      const src = URL.createObjectURL(file);
-      const img = new Image();
-      // eslint-disable-next-line functional/immutable-data
-      img.onload = () => {
-        resolve({
-          src,
-          naturalWidth: img.naturalWidth,
-          naturalHeight: img.naturalHeight,
-        });
-      };
-      // eslint-disable-next-line functional/immutable-data
-      img.onerror = () => {
-        URL.revokeObjectURL(src);
-        resolve(null);
-      };
-      // eslint-disable-next-line functional/immutable-data
-      img.src = src;
-    };
-
-    // eslint-disable-next-line functional/immutable-data
-    input.oncancel = () => {
-      resolve(null);
-    };
-
-    input.click();
-  });
-}
-
 const ItemBox: FC<{
   item: MediaItem;
   onClickClose?: (id: string) => void;
@@ -212,22 +164,20 @@ export const Container: FC = () => {
     ]);
   }, []);
 
-  const clickAddImageHandler = useCallback(async () => {
-    const imageData = await selectImageFile();
-    if (!imageData) {
-      return;
-    }
-
-    setMediaItems((prev) => [
-      ...prev,
-      {
-        type: "image",
-        ...imageData,
-        id: crypto.randomUUID(),
-        color: getPastelColor(prev.length),
-      },
-    ]);
-  }, []);
+  const handleImageChoose = useCallback(
+    (data: { src: string; naturalWidth: number; naturalHeight: number }) => {
+      setMediaItems((prev) => [
+        ...prev,
+        {
+          type: "image",
+          ...data,
+          id: crypto.randomUUID(),
+          color: getPastelColor(prev.length),
+        },
+      ]);
+    },
+    [],
+  );
 
   const clickCloseHandler = useCallback((id: string) => {
     setMediaItems((prev) => {
@@ -283,7 +233,7 @@ export const Container: FC = () => {
       onClickAddTimer={() => clickAddOtherItemHandler("timer")}
       onClickAddClock={() => clickAddOtherItemHandler("clock")}
       onClickAddMemo={() => clickAddOtherItemHandler("memo")}
-      onClickAddImage={clickAddImageHandler}
+      onImageChoose={handleImageChoose}
       isEmpty={mediaItems.length === 0}
     >
       {mediaItems.map((item) => (

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -11,27 +11,29 @@ import Schedule from "@material-design-icons/svg/filled/schedule.svg?react";
 import SwitchVideo from "@material-design-icons/svg/filled/switch_video.svg?react";
 import Timer from "@material-design-icons/svg/filled/timer.svg?react";
 import classNames from "classnames";
-import { ComponentPropsWithoutRef, FC, memo } from "react";
+import { FC, HTMLAttributes, memo } from "react";
 
-interface Props extends ComponentPropsWithoutRef<"button"> {
-  className?: string;
-  iconType:
-    | "add"
-    | "close"
-    | "crop"
-    | "fullscreen_exit"
-    | "help"
-    | "image"
-    | "move_up"
-    | "move_down"
-    | "note"
-    | "switch_video"
-    | "timer"
-    | "schedule";
+type IconType =
+  | "add"
+  | "close"
+  | "crop"
+  | "fullscreen_exit"
+  | "help"
+  | "image"
+  | "move_up"
+  | "move_down"
+  | "note"
+  | "switch_video"
+  | "timer"
+  | "schedule";
+
+interface Props extends HTMLAttributes<HTMLElement> {
+  as?: "button" | "span";
+  iconType: IconType;
   iconColor?: string;
 }
 
-const ICON: Record<Props["iconType"], FC<React.SVGProps<SVGSVGElement>>> = {
+const ICON: Record<IconType, FC<React.SVGProps<SVGSVGElement>>> = {
   add: Add,
   close: Close,
   crop: Crop,
@@ -47,6 +49,7 @@ const ICON: Record<Props["iconType"], FC<React.SVGProps<SVGSVGElement>>> = {
 };
 
 export const Button: FC<Props> = memo(function Button({
+  as: Component = "button",
   className,
   iconType,
   iconColor,
@@ -55,7 +58,7 @@ export const Button: FC<Props> = memo(function Button({
   const Icon = ICON[iconType];
 
   return (
-    <button
+    <Component
       className={classNames(
         className,
         "block rounded-full bg-slate-950/80 p-2 hover:bg-slate-950/50",
@@ -68,6 +71,6 @@ export const Button: FC<Props> = memo(function Button({
         style={{ fill: iconColor || "white" }}
         viewBox='0 0 24 24'
       />
-    </button>
+    </Component>
   );
 });

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -3,7 +3,6 @@ import Close from "@material-design-icons/svg/filled/close.svg?react";
 import Crop from "@material-design-icons/svg/filled/crop.svg?react";
 import FullscreenExit from "@material-design-icons/svg/filled/fullscreen_exit.svg?react";
 import Help from "@material-design-icons/svg/filled/help.svg?react";
-import Image from "@material-design-icons/svg/filled/image.svg?react";
 import KeyboardArrowDown from "@material-design-icons/svg/filled/keyboard_arrow_down.svg?react";
 import KeyboardArrowUp from "@material-design-icons/svg/filled/keyboard_arrow_up.svg?react";
 import Note from "@material-design-icons/svg/filled/note.svg?react";
@@ -21,7 +20,6 @@ interface Props extends ComponentPropsWithoutRef<"button"> {
     | "crop"
     | "fullscreen_exit"
     | "help"
-    | "image"
     | "move_up"
     | "move_down"
     | "note"
@@ -37,7 +35,6 @@ const ICON: Record<Props["iconType"], FC<React.SVGProps<SVGSVGElement>>> = {
   crop: Crop,
   fullscreen_exit: FullscreenExit,
   help: Help,
-  image: Image,
   move_up: KeyboardArrowUp,
   move_down: KeyboardArrowDown,
   note: Note,

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -3,6 +3,7 @@ import Close from "@material-design-icons/svg/filled/close.svg?react";
 import Crop from "@material-design-icons/svg/filled/crop.svg?react";
 import FullscreenExit from "@material-design-icons/svg/filled/fullscreen_exit.svg?react";
 import Help from "@material-design-icons/svg/filled/help.svg?react";
+import Image from "@material-design-icons/svg/filled/image.svg?react";
 import KeyboardArrowDown from "@material-design-icons/svg/filled/keyboard_arrow_down.svg?react";
 import KeyboardArrowUp from "@material-design-icons/svg/filled/keyboard_arrow_up.svg?react";
 import Note from "@material-design-icons/svg/filled/note.svg?react";
@@ -20,6 +21,7 @@ interface Props extends ComponentPropsWithoutRef<"button"> {
     | "crop"
     | "fullscreen_exit"
     | "help"
+    | "image"
     | "move_up"
     | "move_down"
     | "note"
@@ -35,6 +37,7 @@ const ICON: Record<Props["iconType"], FC<React.SVGProps<SVGSVGElement>>> = {
   crop: Crop,
   fullscreen_exit: FullscreenExit,
   help: Help,
+  image: Image,
   move_up: KeyboardArrowUp,
   move_down: KeyboardArrowDown,
   note: Note,

--- a/src/components/ImageBox/index.stories.tsx
+++ b/src/components/ImageBox/index.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ImageBox } from "./index";
+
+const meta = {
+  component: ImageBox,
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof ImageBox>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    src: "https://picsum.photos/800/600",
+    naturalWidth: 800,
+    naturalHeight: 600,
+    color: "#60a5fa",
+  },
+};

--- a/src/components/ImageBox/index.tsx
+++ b/src/components/ImageBox/index.tsx
@@ -1,0 +1,110 @@
+import classNames from "classnames";
+import { ComponentProps, FC, useCallback, useState } from "react";
+
+import { t } from "../../i18n";
+import { Button } from "../Button";
+import { FlexibleBox } from "../FlexibleBox";
+
+interface Props {
+  src: string;
+  naturalWidth: number;
+  naturalHeight: number;
+  color: string;
+  onClickClose?: () => void;
+  onClickMoveUp?: () => void;
+  onClickMoveDown?: () => void;
+}
+
+function detectContentSize(imageWidth: number, imageHeight: number) {
+  const aspectRatio = imageWidth / imageHeight;
+  const maxWidth = window.innerWidth * 0.8;
+  const maxHeight = window.innerHeight * 0.8;
+  const maxAspectRatio = maxWidth / maxHeight;
+
+  if (aspectRatio >= maxAspectRatio && imageWidth > maxWidth) {
+    return { width: maxWidth, height: maxWidth / aspectRatio };
+  }
+  if (aspectRatio < maxAspectRatio && imageHeight > maxHeight) {
+    return { width: maxHeight * aspectRatio, height: maxHeight };
+  }
+
+  return { width: imageWidth, height: imageHeight };
+}
+
+export const ImageBox: FC<Props> = ({
+  src,
+  naturalWidth,
+  naturalHeight,
+  color,
+  onClickClose,
+  onClickMoveUp,
+  onClickMoveDown,
+}) => {
+  const [mode, setMode] =
+    useState<ComponentProps<typeof FlexibleBox>["mode"]>("resize");
+
+  const contentSize = detectContentSize(naturalWidth, naturalHeight);
+
+  const toggleMode = useCallback(() => {
+    setMode((prev) => (prev === "resize" ? "crop" : "resize"));
+  }, []);
+
+  const buttons = (
+    <div
+      className={classNames(
+        "pointer-events-none absolute right-0 top-0 flex flex-row gap-2 p-4",
+        "transition-opacity duration-200 ease-in-out",
+      )}
+    >
+      <Button
+        className='pointer-events-auto'
+        iconType={mode === "resize" ? "crop" : "fullscreen_exit"}
+        iconColor={color}
+        onClick={toggleMode}
+        title={
+          mode === "resize"
+            ? t("imageBox.switchToCrop")
+            : t("imageBox.switchToResize")
+        }
+      />
+      <Button
+        className='pointer-events-auto'
+        iconType='move_up'
+        iconColor={color}
+        onClick={onClickMoveUp}
+        title={t("imageBox.bringToFront")}
+      />
+      <Button
+        className='pointer-events-auto'
+        iconType='move_down'
+        iconColor={color}
+        onClick={onClickMoveDown}
+        title={t("imageBox.sendToBack")}
+      />
+      <Button
+        className='pointer-events-auto'
+        iconType='close'
+        iconColor={color}
+        onClick={onClickClose}
+        title={t("imageBox.closeImage")}
+      />
+    </div>
+  );
+
+  return (
+    <FlexibleBox
+      contentWidth={contentSize.width}
+      contentHeight={contentSize.height}
+      mode={mode}
+      borderColor={color}
+      buttons={buttons}
+    >
+      <img
+        src={src}
+        className='pointer-events-none size-full object-contain'
+        alt=''
+        draggable={false}
+      />
+    </FlexibleBox>
+  );
+};

--- a/src/components/ImageBox/index.tsx
+++ b/src/components/ImageBox/index.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { ComponentProps, FC, useCallback, useState } from "react";
+import { ComponentProps, FC, useCallback, useMemo, useState } from "react";
 
 import { t } from "../../i18n";
 import { Button } from "../Button";
@@ -43,7 +43,10 @@ export const ImageBox: FC<Props> = ({
   const [mode, setMode] =
     useState<ComponentProps<typeof FlexibleBox>["mode"]>("resize");
 
-  const contentSize = detectContentSize(naturalWidth, naturalHeight);
+  const contentSize = useMemo(
+    () => detectContentSize(naturalWidth, naturalHeight),
+    [naturalWidth, naturalHeight],
+  );
 
   const toggleMode = useCallback(() => {
     setMode((prev) => (prev === "resize" ? "crop" : "resize"));
@@ -98,6 +101,7 @@ export const ImageBox: FC<Props> = ({
       mode={mode}
       borderColor={color}
       buttons={buttons}
+      transparent
     >
       <img
         src={src}

--- a/src/components/ImageFileChooser/index.stories.tsx
+++ b/src/components/ImageFileChooser/index.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ImageFileChooser } from "./index";
+
+const meta = {
+  component: ImageFileChooser,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    onImageChoose: { action: "imageChosen" },
+  },
+} satisfies Meta<typeof ImageFileChooser>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    onImageChoose: () => {},
+  },
+};

--- a/src/components/ImageFileChooser/index.tsx
+++ b/src/components/ImageFileChooser/index.tsx
@@ -1,6 +1,6 @@
-import ImageIcon from "@material-design-icons/svg/filled/image.svg?react";
-import classNames from "classnames";
-import { FC, useCallback, useId, useRef, useState } from "react";
+import { FC, useCallback, useRef, useState } from "react";
+
+import { Button } from "../Button";
 
 interface Props {
   className?: string;
@@ -17,9 +17,12 @@ export const ImageFileChooser: FC<Props> = ({
   title,
   onImageChoose,
 }) => {
-  const inputId = useId();
   const inputRef = useRef<HTMLInputElement>(null);
   const [imageSrc, setImageSrc] = useState<string | null>(null);
+
+  const handleClick = useCallback(() => {
+    inputRef.current?.click();
+  }, []);
 
   const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -36,10 +39,6 @@ export const ImageFileChooser: FC<Props> = ({
         naturalHeight: img.naturalHeight,
       });
       setImageSrc(null);
-      if (inputRef.current) {
-        // eslint-disable-next-line functional/immutable-data
-        inputRef.current.value = "";
-      }
     },
     [onImageChoose],
   );
@@ -53,24 +52,14 @@ export const ImageFileChooser: FC<Props> = ({
 
   return (
     <>
-      <label
-        htmlFor={inputId}
-        className={classNames(
-          className,
-          "block rounded-full bg-slate-950/80 p-2 hover:bg-slate-950/50",
-          "transition-bg duration-200 ease-in-out cursor-pointer",
-        )}
+      <Button
+        className={className}
+        iconType='image'
         title={title}
-      >
-        <ImageIcon
-          className='block size-5 object-contain'
-          style={{ fill: "white" }}
-          viewBox='0 0 24 24'
-        />
-      </label>
+        onClick={handleClick}
+      />
       <input
         ref={inputRef}
-        id={inputId}
         type='file'
         accept='image/*'
         className='hidden'

--- a/src/components/ImageFileChooser/index.tsx
+++ b/src/components/ImageFileChooser/index.tsx
@@ -1,0 +1,90 @@
+import ImageIcon from "@material-design-icons/svg/filled/image.svg?react";
+import classNames from "classnames";
+import { FC, useCallback, useId, useRef, useState } from "react";
+
+interface Props {
+  className?: string;
+  title?: string;
+  onImageChoose: (data: {
+    src: string;
+    naturalWidth: number;
+    naturalHeight: number;
+  }) => void;
+}
+
+export const ImageFileChooser: FC<Props> = ({
+  className,
+  title,
+  onImageChoose,
+}) => {
+  const inputId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [imageSrc, setImageSrc] = useState<string | null>(null);
+
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setImageSrc(URL.createObjectURL(file));
+  }, []);
+
+  const handleLoad = useCallback(
+    (e: React.SyntheticEvent<HTMLImageElement>) => {
+      const img = e.currentTarget;
+      onImageChoose({
+        src: img.src,
+        naturalWidth: img.naturalWidth,
+        naturalHeight: img.naturalHeight,
+      });
+      setImageSrc(null);
+      if (inputRef.current) {
+        // eslint-disable-next-line functional/immutable-data
+        inputRef.current.value = "";
+      }
+    },
+    [onImageChoose],
+  );
+
+  const handleError = useCallback(() => {
+    if (imageSrc) {
+      URL.revokeObjectURL(imageSrc);
+    }
+    setImageSrc(null);
+  }, [imageSrc]);
+
+  return (
+    <>
+      <label
+        htmlFor={inputId}
+        className={classNames(
+          className,
+          "block rounded-full bg-slate-950/80 p-2 hover:bg-slate-950/50",
+          "transition-bg duration-200 ease-in-out cursor-pointer",
+        )}
+        title={title}
+      >
+        <ImageIcon
+          className='block size-5 object-contain'
+          style={{ fill: "white" }}
+          viewBox='0 0 24 24'
+        />
+      </label>
+      <input
+        ref={inputRef}
+        id={inputId}
+        type='file'
+        accept='image/*'
+        className='hidden'
+        onChange={handleChange}
+      />
+      {imageSrc && (
+        <img
+          src={imageSrc}
+          className='hidden'
+          onLoad={handleLoad}
+          onError={handleError}
+          alt=''
+        />
+      )}
+    </>
+  );
+};

--- a/src/components/ImageFileChooser/index.tsx
+++ b/src/components/ImageFileChooser/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useRef, useState } from "react";
+import { FC, useCallback, useState } from "react";
 
 import { Button } from "../Button";
 
@@ -17,17 +17,14 @@ export const ImageFileChooser: FC<Props> = ({
   title,
   onImageChoose,
 }) => {
-  const inputRef = useRef<HTMLInputElement>(null);
   const [imageSrc, setImageSrc] = useState<string | null>(null);
-
-  const handleClick = useCallback(() => {
-    inputRef.current?.click();
-  }, []);
 
   const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
     setImageSrc(URL.createObjectURL(file));
+    // eslint-disable-next-line functional/immutable-data
+    e.target.value = "";
   }, []);
 
   const handleLoad = useCallback(
@@ -51,15 +48,9 @@ export const ImageFileChooser: FC<Props> = ({
   }, [imageSrc]);
 
   return (
-    <>
-      <Button
-        className={className}
-        iconType='image'
-        title={title}
-        onClick={handleClick}
-      />
+    <label className={className} title={title}>
+      <Button as='span' iconType='image' />
       <input
-        ref={inputRef}
         type='file'
         accept='image/*'
         className='hidden'
@@ -74,6 +65,6 @@ export const ImageFileChooser: FC<Props> = ({
           alt=''
         />
       )}
-    </>
+    </label>
   );
 };

--- a/src/components/MainCanvas/index.tsx
+++ b/src/components/MainCanvas/index.tsx
@@ -11,6 +11,7 @@ type Props = PropsWithChildren<{
   onClickAddTimer?: () => void;
   onClickAddClock?: () => void;
   onClickAddMemo?: () => void;
+  onClickAddImage?: () => void;
   isEmpty?: boolean;
 }>;
 
@@ -21,6 +22,7 @@ export const MainCanvas: FC<Props> = ({
   onClickAddTimer,
   onClickAddClock,
   onClickAddMemo,
+  onClickAddImage,
   isEmpty = false,
 }) => {
   return (
@@ -39,6 +41,12 @@ export const MainCanvas: FC<Props> = ({
           isEmpty ? "opacity-100" : "opacity-0 group-hover/main:opacity-100",
         )}
       >
+        <Button
+          className='pointer-events-auto'
+          iconType='image'
+          onClick={onClickAddImage}
+          title={t("mainCanvas.addImage")}
+        />
         <Button
           className='pointer-events-auto'
           iconType='note'

--- a/src/components/MainCanvas/index.tsx
+++ b/src/components/MainCanvas/index.tsx
@@ -3,6 +3,7 @@ import { FC, PropsWithChildren } from "react";
 
 import { t } from "../../i18n";
 import { Button } from "../Button";
+import { ImageFileChooser } from "../ImageFileChooser";
 import { WelcomeOverlay } from "../WelcomeOverlay";
 
 type Props = PropsWithChildren<{
@@ -11,7 +12,11 @@ type Props = PropsWithChildren<{
   onClickAddTimer?: () => void;
   onClickAddClock?: () => void;
   onClickAddMemo?: () => void;
-  onClickAddImage?: () => void;
+  onImageChoose?: (data: {
+    src: string;
+    naturalWidth: number;
+    naturalHeight: number;
+  }) => void;
   isEmpty?: boolean;
 }>;
 
@@ -22,7 +27,7 @@ export const MainCanvas: FC<Props> = ({
   onClickAddTimer,
   onClickAddClock,
   onClickAddMemo,
-  onClickAddImage,
+  onImageChoose,
   isEmpty = false,
 }) => {
   return (
@@ -41,12 +46,13 @@ export const MainCanvas: FC<Props> = ({
           isEmpty ? "opacity-100" : "opacity-0 group-hover/main:opacity-100",
         )}
       >
-        <Button
-          className='pointer-events-auto'
-          iconType='image'
-          onClick={onClickAddImage}
-          title={t("mainCanvas.addImage")}
-        />
+        {onImageChoose && (
+          <ImageFileChooser
+            className='pointer-events-auto'
+            onImageChoose={onImageChoose}
+            title={t("mainCanvas.addImage")}
+          />
+        )}
         <Button
           className='pointer-events-auto'
           iconType='note'

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -15,6 +15,7 @@ export const en = {
   "mainCanvas.addClock": "Add Clock",
   "mainCanvas.addTimer": "Add Timer",
   "mainCanvas.addMemo": "Add Memo",
+  "mainCanvas.addImage": "Add Image",
 
   // Stream Box
   "streamBox.resize": "Resize",
@@ -29,4 +30,11 @@ export const en = {
   "streamBox.bringToFront": "Bring to front",
   "streamBox.sendToBack": "Send to back",
   "streamBox.closeStream": "Close stream",
+
+  // Image Box
+  "imageBox.switchToCrop": "Switch to crop mode",
+  "imageBox.switchToResize": "Switch to resize mode",
+  "imageBox.bringToFront": "Bring to front",
+  "imageBox.sendToBack": "Send to back",
+  "imageBox.closeImage": "Close image",
 } as const;

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -18,6 +18,7 @@ export const ja = {
   "mainCanvas.addClock": "時計を追加",
   "mainCanvas.addTimer": "タイマーを追加",
   "mainCanvas.addMemo": "メモを追加",
+  "mainCanvas.addImage": "画像を追加",
 
   // Stream Box
   "streamBox.resize": "リサイズ",
@@ -32,4 +33,11 @@ export const ja = {
   "streamBox.bringToFront": "前面に移動",
   "streamBox.sendToBack": "背面に移動",
   "streamBox.closeStream": "閉じる",
+
+  // Image Box
+  "imageBox.switchToCrop": "クロップモードに切り替え",
+  "imageBox.switchToResize": "リサイズモードに切り替え",
+  "imageBox.bringToFront": "前面に移動",
+  "imageBox.sendToBack": "背面に移動",
+  "imageBox.closeImage": "画像を閉じる",
 } as const satisfies Record<keyof typeof en, string>;


### PR DESCRIPTION
## Summary
This PR adds the ability to upload and display images on the canvas, allowing users to add image files to their workspace alongside existing stream, timer, clock, and memo items.

## Key Changes
- **New ImageItem type**: Added `ImageItem` type to the `MediaItem` union, storing image source, natural dimensions, and metadata
- **Image file selection**: Implemented `selectImageFile()` function that opens a file picker, loads the image, and captures its natural dimensions
- **ImageBox component**: Created new `ImageBox` component that displays images with resize/crop mode toggle and layer management controls
- **Canvas integration**: Added "Add Image" button to the main canvas toolbar with corresponding handler
- **Resource cleanup**: Implemented proper cleanup of object URLs when images are removed from the canvas
- **Internationalization**: Added English and Japanese translations for all new UI elements

## Implementation Details
- Images are loaded via `URL.createObjectURL()` for efficient in-memory handling
- Automatic content sizing respects aspect ratio while fitting within 80% of viewport dimensions
- ImageBox supports both resize and crop modes, consistent with StreamBox functionality
- Proper memory management with `URL.revokeObjectURL()` on image removal
- Material Design image icon added to the Button component

https://claude.ai/code/session_01HUVHyKvfD8L7ay888aG4V9